### PR TITLE
making the not-windows fallback actually work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbowalk",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "directory walking, using platform-specific optimizations if available",
   "scripts": {
     "install": "autogypi && node-gyp configure build"

--- a/walk.js
+++ b/walk.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
 const fs = require('fs-extra');
+const path = require('path');
 
 function walk(target,
               callback,


### PR DESCRIPTION
`ReferenceError: path is not defined`